### PR TITLE
More performance optimisations

### DIFF
--- a/lib/json_p3/filter.rb
+++ b/lib/json_p3/filter.rb
@@ -359,7 +359,7 @@ module JSONP3 # rubocop:disable Style/Documentation
     def unpack_node_lists(func, args) # rubocop:disable Metrics/MethodLength
       unpacked_args = []
       args.each_with_index do |arg, i|
-        unless arg.is_a?(JSONPathNodeList) && func.class::ARG_TYPES[i] != ExpressionType::NODES
+        unless arg.is_a?(JSONPathNodeList) && func.class::ARG_TYPES[i] != :nodes_expression
           unpacked_args << arg
           next
         end

--- a/lib/json_p3/function.rb
+++ b/lib/json_p3/function.rb
@@ -1,12 +1,6 @@
 # frozen_string_literal: true
 
 module JSONP3
-  class ExpressionType
-    VALUE = :value_expression
-    LOGICAL = :logical_expression
-    NODES = :nodes_expression
-  end
-
   # Base class for all filter functions.
   class FunctionExtension
     def call(*_args, **_kwargs)

--- a/lib/json_p3/function_extensions/count.rb
+++ b/lib/json_p3/function_extensions/count.rb
@@ -5,8 +5,8 @@ require_relative "../function"
 module JSONP3
   # The standard `count` function.
   class Count < FunctionExtension
-    ARG_TYPES = [ExpressionType::NODES].freeze
-    RETURN_TYPE = ExpressionType::VALUE
+    ARG_TYPES = [:nodes_expression].freeze
+    RETURN_TYPE = :value_expression
 
     def call(node_list)
       node_list.length

--- a/lib/json_p3/function_extensions/length.rb
+++ b/lib/json_p3/function_extensions/length.rb
@@ -5,8 +5,8 @@ require_relative "../function"
 module JSONP3
   # The standard `length` function.
   class Length < FunctionExtension
-    ARG_TYPES = [ExpressionType::VALUE].freeze
-    RETURN_TYPE = ExpressionType::VALUE
+    ARG_TYPES = [:value_expression].freeze
+    RETURN_TYPE = :value_expression
 
     def call(obj)
       return :nothing unless obj.is_a?(Array) || obj.is_a?(Hash) || obj.is_a?(String)

--- a/lib/json_p3/function_extensions/match.rb
+++ b/lib/json_p3/function_extensions/match.rb
@@ -7,8 +7,8 @@ require_relative "pattern"
 module JSONP3
   # The standard `match` function.
   class Match < FunctionExtension
-    ARG_TYPES = [ExpressionType::VALUE, ExpressionType::VALUE].freeze
-    RETURN_TYPE = ExpressionType::LOGICAL
+    ARG_TYPES = %i[value_expression value_expression].freeze
+    RETURN_TYPE = :logical_expression
 
     # @param cache_size [Integer] the maximum size of the regexp cache. Set it to
     #   zero or negative to disable the cache.

--- a/lib/json_p3/function_extensions/search.rb
+++ b/lib/json_p3/function_extensions/search.rb
@@ -7,8 +7,8 @@ require_relative "pattern"
 module JSONP3
   # The standard `search` function.
   class Search < FunctionExtension
-    ARG_TYPES = [ExpressionType::VALUE, ExpressionType::VALUE].freeze
-    RETURN_TYPE = ExpressionType::LOGICAL
+    ARG_TYPES = %i[value_expression value_expression].freeze
+    RETURN_TYPE = :logical_expression
 
     # @param cache_size [Integer] the maximum size of the regexp cache. Set it to
     #   zero or negative to disable the cache.

--- a/lib/json_p3/function_extensions/value.rb
+++ b/lib/json_p3/function_extensions/value.rb
@@ -5,8 +5,8 @@ require_relative "../function"
 module JSONP3
   # The standard `value` function.
   class Value < FunctionExtension
-    ARG_TYPES = [ExpressionType::NODES].freeze
-    RETURN_TYPE = ExpressionType::VALUE
+    ARG_TYPES = [:nodes_expression].freeze
+    RETURN_TYPE = :value_expression
 
     def call(node_list)
       node_list.length == 1 ? node_list.first.value : :nothing

--- a/lib/json_p3/lexer.rb
+++ b/lib/json_p3/lexer.rb
@@ -56,7 +56,7 @@ module JSONP3 # rubocop:disable Style/Documentation
     # @param value [String | nil] a the token's value, if it is known, otherwise the
     #   value will be sliced from @query. This is a performance optimization.
     def emit(token_type, value = nil)
-      @tokens << Token.new(token_type, value || @query[@start...@scanner.charpos], @start, @query)
+      @tokens << Token.new(token_type, value || @query[@start, @scanner.charpos - @start], @start, @query)
       @start = @scanner.charpos
     end
 
@@ -99,7 +99,7 @@ module JSONP3 # rubocop:disable Style/Documentation
 
     def error(message)
       @tokens << Token.new(
-        :token_error, @query[@start...@scanner.charpos] || "", @start, @query, message: message
+        :token_error, @query[@start, @scanner.charpos - @start] || "", @start, @query, message: message
       )
     end
 

--- a/lib/json_p3/parser.rb
+++ b/lib/json_p3/parser.rb
@@ -232,7 +232,7 @@ module JSONP3
       # Raise if expression must be compared.
       if expression.is_a? FunctionExpression
         func = @env.function_extensions[expression.name]
-        if func.class::RETURN_TYPE == ExpressionType::VALUE
+        if func.class::RETURN_TYPE == :value_expression
           raise JSONPathTypeError.new("result of #{expression.name}() must be compared", expression.token)
         end
       end
@@ -465,7 +465,7 @@ module JSONP3
       return unless expression.is_a?(FunctionExpression)
 
       func = @env.function_extensions[expression.name]
-      return unless func.class::RETURN_TYPE != ExpressionType::VALUE
+      return unless func.class::RETURN_TYPE != :value_expression
 
       raise JSONPathTypeError.new("result of #{expression.name}() is not comparable", expression.token)
     end
@@ -491,18 +491,18 @@ module JSONP3
       func.class::ARG_TYPES.each_with_index do |t, i|
         arg = args[i]
         case t
-        when ExpressionType::VALUE
+        when :value_expression
           unless arg.is_a?(FilterExpressionLiteral) ||
                  (arg.is_a?(QueryExpression) && arg.query.singular?) ||
-                 (function_return_type(arg) == ExpressionType::VALUE)
+                 (function_return_type(arg) == :value_expression)
             raise JSONPathTypeError.new("#{token.value}() argument #{i} must be of ValueType", arg.token)
           end
-        when ExpressionType::LOGICAL
+        when :logical_expression
           unless arg.is_a?(QueryExpression) || arg.is_a?(InfixExpression)
             raise JSONPathTypeError.new("#{token.value}() argument #{i} must be of LogicalType", arg.token)
           end
-        when ExpressionType::NODES
-          unless arg.is_a?(QueryExpression) || function_return_type(arg) == ExpressionType::NODES
+        when :nodes_expression
+          unless arg.is_a?(QueryExpression) || function_return_type(arg) == :nodes_expression
             raise JSONPathTypeError.new("#{token.value}() argument #{i} must be of NodesType", arg.token)
           end
         end

--- a/lib/json_p3/segment.rb
+++ b/lib/json_p3/segment.rb
@@ -21,7 +21,7 @@ module JSONP3
   # The child selection segment.
   class ChildSegment < Segment
     def resolve(nodes)
-      rv = []
+      rv = [] # : Array[JSONPathNode]
       nodes.each do |node|
         @selectors.each do |selector|
           rv.concat selector.resolve(node)
@@ -50,7 +50,7 @@ module JSONP3
   # The recursive descent segment
   class RecursiveDescentSegment < Segment
     def resolve(nodes)
-      rv = []
+      rv = [] # : Array[JSONPathNode]
       nodes.each do |node|
         visit(node).each do |descendant|
           @selectors.each do |selector|

--- a/lib/json_p3/selector.rb
+++ b/lib/json_p3/selector.rb
@@ -249,7 +249,7 @@ module JSONP3
     end
 
     def resolve(node) # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
-      nodes = []
+      nodes = [] # : Array[JSONPathNode]
 
       if node.value.is_a?(Array)
         node.value.each_with_index do |e, i|

--- a/lib/json_p3/token.rb
+++ b/lib/json_p3/token.rb
@@ -7,44 +7,6 @@ module JSONP3
   # string from a JSONPath expression, its location within the JSONPath expression and a
   # symbol indicating what type of token it is.
   class Token
-    EOI = :token_eoi
-    ERROR = :token_error
-
-    SHORTHAND_NAME = :token_shorthand_name
-    COLON = :token_colon
-    COMMA = :token_comma
-    DOT = :token_dot
-    DOUBLE_DOT = :token_double_dot
-    FILTER = :token_filter
-    INDEX = :token_index
-    LBRACKET = :token_lbracket
-    NAME = :token_name
-    RBRACKET = :token_rbracket
-    ROOT = :token_root
-    WILD = :token_wild
-
-    AND = :token_and
-    CURRENT = :token_current
-    DOUBLE_QUOTE_STRING = :token_double_quote_string
-    EQ = :token_eq
-    FALSE = :token_false
-    FLOAT = :token_float
-    FUNCTION = :token_function
-    GE = :token_ge
-    GT = :token_gt
-    INT = :token_int
-    LE = :token_le
-    LPAREN = :token_lparen
-    LT = :token_lt
-    NE = :token_ne
-    NOT = :token_not
-    NULL = :token_null
-    OP = :token_op
-    OR = :token_or
-    RPAREN = :token_rparen
-    SINGLE_QUOTE_STRING = :token_single_quote_string
-    TRUE = :token_true
-
     # @dynamic type, value, start, query, message
     attr_reader :type, :value, :start, :query, :message
 

--- a/lib/json_p3/unescape.rb
+++ b/lib/json_p3/unescape.rb
@@ -57,7 +57,7 @@ module JSONP3 # rubocop:disable Style/Documentation
     raise JSONPathSyntaxError.new("incomplete escape sequence", token) if index + 4 >= length
 
     index += 1 # move past 'u'
-    code_point = parse_hex_digits(value[index...index + 4], token)
+    code_point = parse_hex_digits(value[index, 4], token)
 
     raise JSONPathSyntaxError.new("unexpected low surrogate", token) if low_surrogate?(code_point)
 
@@ -67,7 +67,7 @@ module JSONP3 # rubocop:disable Style/Documentation
       raise JSONPathSyntaxError.new("incomplete escape sequence", token)
     end
 
-    low_surrogate = parse_hex_digits(value[index + 6...index + 10], token)
+    low_surrogate = parse_hex_digits(value[index + 6, 10], token)
 
     raise JSONPathSyntaxError.new("unexpected low surrogate", token) unless low_surrogate?(low_surrogate)
 

--- a/sig/json_p3.rbs
+++ b/sig/json_p3.rbs
@@ -351,20 +351,14 @@ module JSONP3
   end
 end
 
+type expression_t = :value_expression | :logical_expression | :nodes_expression
+
 module JSONP3
-  class ExpressionType
-    VALUE: :value_expression
-
-    LOGICAL: :logical_expression
-
-    NODES: :nodes_expression
-  end
-
   # Base class for all filter functions.
   class FunctionExtension
-    ARG_TYPES: ::Array[Symbol]
+    ARG_TYPES: Array[expression_t]
 
-    RETURN_TYPE: Symbol
+    RETURN_TYPE: expression_t
 
     def call: (*untyped _args, **untyped _kwargs) -> untyped
   end
@@ -581,7 +575,7 @@ module JSONP3
 
     def validate_function_extension_signature: (Token token, untyped args) -> void
 
-    def function_return_type: (Expression expression) -> (Symbol | nil)
+    def function_return_type: (Expression expression) -> (expression_t | nil)
 
     PRECEDENCES: ::Hash[token_t, Integer]
 
@@ -930,9 +924,9 @@ end
 module JSONP3
   # The standard `count` function.
   class Count < FunctionExtension
-    ARG_TYPES: ::Array[Symbol]
+    ARG_TYPES: Array[expression_t]
 
-    RETURN_TYPE: Symbol
+    RETURN_TYPE: expression_t
 
     def call: (JSONPathNodeList node_list) -> untyped
   end
@@ -941,9 +935,9 @@ end
 module JSONP3
   # The standard `length` function.
   class Length < FunctionExtension
-    ARG_TYPES: ::Array[Symbol]
+    ARG_TYPES: Array[expression_t]
 
-    RETURN_TYPE: Symbol
+    RETURN_TYPE: expression_t
 
     def call: (untyped obj) -> (:nothing | untyped)
   end
@@ -958,9 +952,9 @@ module JSONP3
 
     @cache: LRUCache
 
-    ARG_TYPES: ::Array[Symbol]
+    ARG_TYPES: Array[expression_t]
 
-    RETURN_TYPE: Symbol
+    RETURN_TYPE: expression_t
 
     # @param cache_size [Integer] the maximum size of the regexp cache. Set it to
     #   zero or negative to disable the cache.
@@ -995,9 +989,9 @@ module JSONP3
 
     @cache: LRUCache
 
-    ARG_TYPES: ::Array[Symbol]
+    ARG_TYPES: Array[expression_t]
 
-    RETURN_TYPE: Symbol
+    RETURN_TYPE: expression_t
 
     # @param cache_size [Integer] the maximum size of the regexp cache. Set it to
     #   zero or negative to disable the cache.
@@ -1015,9 +1009,9 @@ end
 module JSONP3
   # The standard `value` function.
   class Value < FunctionExtension
-    ARG_TYPES: ::Array[Symbol]
+    ARG_TYPES: Array[expression_t]
 
-    RETURN_TYPE: Symbol
+    RETURN_TYPE: expression_t
 
     def call: (JSONPathNodeList node_list) -> (untyped | :nothing)
   end

--- a/sig/json_p3.rbs
+++ b/sig/json_p3.rbs
@@ -412,7 +412,7 @@ module JSONP3
     # @param token_type [Symbol] one of the constants defined on the _Token_ class.
     # @param value [String | nil] a the token's value, if it is known, otherwise the
     #   value will be sliced from @query. This is a performance optimisation.
-    def emit: (Symbol token_type, ?untyped value) -> void
+    def emit: (token_t token_type, ?untyped value) -> void
 
     def next: () -> String
 
@@ -445,7 +445,7 @@ module JSONP3
 
     def lex_inside_filter: () -> untyped
 
-    def self.lex_string_factory: (String quote, Symbol state, Symbol token) -> untyped
+    def self.lex_string_factory: (String quote, Symbol state, token_t token) -> untyped
   end
 end
 
@@ -507,9 +507,9 @@ module JSONP3
 
     def peek: () -> Token
 
-    def expect: (Symbol token_type) -> void
+    def expect: (token_t token_type) -> void
 
-    def expect_not: (Symbol token_type, String message) -> void
+    def expect_not: (token_t token_type, String message) -> void
 
     def to_s: () -> ::String
   end
@@ -577,15 +577,15 @@ module JSONP3
 
     def raise_for_non_comparable_function: (Expression expression) -> void
 
-    def raise_for_uncompared_literal: (Expression expression) -> void
+    def raise_for_not_compared_literal: (Expression expression) -> void
 
     def validate_function_extension_signature: (Token token, untyped args) -> void
 
     def function_return_type: (Expression expression) -> (Symbol | nil)
 
-    PRECEDENCES: ::Hash[Symbol, Integer]
+    PRECEDENCES: ::Hash[token_t, Integer]
 
-    BINARY_OPERATORS: ::Hash[Symbol, "&&" | "||" | "==" | ">=" | ">" | "<=" | "<" | "!="]
+    BINARY_OPERATORS: ::Hash[token_t, "&&" | "||" | "==" | ">=" | ">" | "<=" | "<" | "!="]
 
     COMPARISON_OPERATORS: Set[String]
   end
@@ -828,12 +828,48 @@ module JSONP3
   end
 end
 
+type token_t = (
+  :token_eoi |
+  :token_error |
+  :token_colon |
+  :token_comma |
+  :token_double_dot |
+  :token_filter |
+  :token_index |
+  :token_lbracket |
+  :token_name |
+  :token_rbracket |
+  :token_root |
+  :token_wild |
+  :token_and |
+  :token_current |
+  :token_double_quote_string |
+  :token_eq |
+  :token_false |
+  :token_float |
+  :token_function |
+  :token_ge |
+  :token_gt |
+  :token_int |
+  :token_le |
+  :token_lparen |
+  :token_lt |
+  :token_ne |
+  :token_not |
+  :token_null |
+  :token_or |
+  :token_rparen |
+  :token_single_quote_string |
+  :token_true
+)
+    
+
 module JSONP3
   # Tokens are produced by the lexer and consumed by the parser. Each token contains sub
   # string from a JSONPath expression, its location within the JSONPath expression and a
   # symbol indicating what type of token it is.
   class Token
-    @type: Symbol
+    @type: token_t
 
     @value: String
 
@@ -843,78 +879,8 @@ module JSONP3
 
     @message: (String | nil)
 
-    EOI: :token_eoi
-
-    ERROR: :token_error
-
-    SHORTHAND_NAME: :token_shorthand_name
-
-    COLON: :token_colon
-
-    COMMA: :token_comma
-
-    DOT: :token_dot
-
-    DOUBLE_DOT: :token_double_dot
-
-    FILTER: :token_filter
-
-    INDEX: :token_index
-
-    LBRACKET: :token_lbracket
-
-    NAME: :token_name
-
-    RBRACKET: :token_rbracket
-
-    ROOT: :token_root
-
-    WILD: :token_wild
-
-    AND: :token_and
-
-    CURRENT: :token_current
-
-    DOUBLE_QUOTE_STRING: :token_double_quote_string
-
-    EQ: :token_eq
-
-    FALSE: :token_false
-
-    FLOAT: :token_float
-
-    FUNCTION: :token_function
-
-    GE: :token_ge
-
-    GT: :token_gt
-
-    INT: :token_int
-
-    LE: :token_le
-
-    LPAREN: :token_lparen
-
-    LT: :token_lt
-
-    NE: :token_ne
-
-    NOT: :token_not
-
-    NULL: :token_null
-
-    OP: :token_op
-
-    OR: :token_or
-
-    RPAREN: :token_rparen
-
-    SINGLE_QUOTE_STRING: :token_single_quote_string
-
-    TRUE: :token_true
-
     # @dynamic type, value, start, query
-    attr_reader type: Symbol
+    attr_reader type: token_t
 
     # @dynamic type, value, start, query
     attr_reader value: String
@@ -928,7 +894,7 @@ module JSONP3
     # @dynamic type, value, start, query
     attr_reader message: (String | nil)
 
-    def initialize: (Symbol type, String value, Integer start, String query, ?message: (String | nil)?) -> void
+    def initialize: (token_t type, String value, Integer start, String query, ?message: (String | nil)?) -> void
 
     def ==: (untyped other) -> bool
 

--- a/test/test_lexer.rb
+++ b/test/test_lexer.rb
@@ -9,52 +9,52 @@ TEST_CASES = [
     name: "basic shorthand name",
     query: "$.foo.bar",
     want: [
-      Token.new(Token::ROOT, "$", 0, "$.foo.bar"),
-      Token.new(Token::NAME, "foo", 2, "$.foo.bar"),
-      Token.new(Token::NAME, "bar", 6, "$.foo.bar"),
-      Token.new(Token::EOI, "", 9, "$.foo.bar")
+      Token.new(:token_root, "$", 0, "$.foo.bar"),
+      Token.new(:token_name, "foo", 2, "$.foo.bar"),
+      Token.new(:token_name, "bar", 6, "$.foo.bar"),
+      Token.new(:token_eoi, "", 9, "$.foo.bar")
     ]
   },
   {
     name: "bracketed name",
     query: "$['foo']['bar']",
     want: [
-      Token.new(Token::ROOT, "$", 0, "$['foo']['bar']"),
-      Token.new(Token::LBRACKET, "[", 1, "$['foo']['bar']"),
-      Token.new(Token::SINGLE_QUOTE_STRING, "foo", 3, "$['foo']['bar']"),
-      Token.new(Token::RBRACKET, "]", 7, "$['foo']['bar']"),
-      Token.new(Token::LBRACKET, "[", 8, "$['foo']['bar']"),
-      Token.new(Token::SINGLE_QUOTE_STRING, "bar", 10, "$['foo']['bar']"),
-      Token.new(Token::RBRACKET, "]", 14, "$['foo']['bar']"),
-      Token.new(Token::EOI, "", 15, "$['foo']['bar']")
+      Token.new(:token_root, "$", 0, "$['foo']['bar']"),
+      Token.new(:token_lbracket, "[", 1, "$['foo']['bar']"),
+      Token.new(:token_single_quote_string, "foo", 3, "$['foo']['bar']"),
+      Token.new(:token_rbracket, "]", 7, "$['foo']['bar']"),
+      Token.new(:token_lbracket, "[", 8, "$['foo']['bar']"),
+      Token.new(:token_single_quote_string, "bar", 10, "$['foo']['bar']"),
+      Token.new(:token_rbracket, "]", 14, "$['foo']['bar']"),
+      Token.new(:token_eoi, "", 15, "$['foo']['bar']")
     ]
   },
   {
     name: "basic index",
     query: "$.foo[1]",
     want: [
-      Token.new(Token::ROOT, "$", 0, "$.foo[1]"),
-      Token.new(Token::NAME, "foo", 2, "$.foo[1]"),
-      Token.new(Token::LBRACKET, "[", 5, "$.foo[1]"),
-      Token.new(Token::INDEX, "1", 6, "$.foo[1]"),
-      Token.new(Token::RBRACKET, "]", 7, "$.foo[1]"),
-      Token.new(Token::EOI, "", 8, "$.foo[1]")
+      Token.new(:token_root, "$", 0, "$.foo[1]"),
+      Token.new(:token_name, "foo", 2, "$.foo[1]"),
+      Token.new(:token_lbracket, "[", 5, "$.foo[1]"),
+      Token.new(:token_index, "1", 6, "$.foo[1]"),
+      Token.new(:token_rbracket, "]", 7, "$.foo[1]"),
+      Token.new(:token_eoi, "", 8, "$.foo[1]")
     ]
   },
   {
     name: "missing root selector",
     query: "foo.bar",
     want: [
-      Token.new(Token::ERROR, "f", 0, "foo.bar", message: "expected '$', found 'f'")
+      Token.new(:token_error, "f", 0, "foo.bar", message: "expected '$', found 'f'")
     ]
   },
   {
     name: "root property selector without dot",
     query: "$foo",
     want: [
-      Token.new(Token::ROOT, "$", 0, "$foo"),
+      Token.new(:token_root, "$", 0, "$foo"),
       Token.new(
-        Token::ERROR,
+        :token_error,
         "f",
         1,
         "$foo",
@@ -66,58 +66,58 @@ TEST_CASES = [
     name: "whitespace after root",
     query: "$ .foo.bar",
     want: [
-      Token.new(Token::ROOT, "$", 0, "$ .foo.bar"),
-      Token.new(Token::NAME, "foo", 3, "$ .foo.bar"),
-      Token.new(Token::NAME, "bar", 7, "$ .foo.bar"),
-      Token.new(Token::EOI, "", 10, "$ .foo.bar")
+      Token.new(:token_root, "$", 0, "$ .foo.bar"),
+      Token.new(:token_name, "foo", 3, "$ .foo.bar"),
+      Token.new(:token_name, "bar", 7, "$ .foo.bar"),
+      Token.new(:token_eoi, "", 10, "$ .foo.bar")
     ]
   },
   {
     name: "whitespace before dot property",
     query: "$. foo.bar",
     want: [
-      Token.new(Token::ROOT, "$", 0, "$. foo.bar"),
-      Token.new(Token::ERROR, " ", 2, "$. foo.bar", message: "unexpected whitespace after dot")
+      Token.new(:token_root, "$", 0, "$. foo.bar"),
+      Token.new(:token_error, " ", 2, "$. foo.bar", message: "unexpected whitespace after dot")
     ]
   },
   {
     name: "whitespace after dot property",
     query: "$.foo .bar",
     want: [
-      Token.new(Token::ROOT, "$", 0, "$.foo .bar"),
-      Token.new(Token::NAME, "foo", 2, "$.foo .bar"),
-      Token.new(Token::NAME, "bar", 7, "$.foo .bar"),
-      Token.new(Token::EOI, "", 10, "$.foo .bar")
+      Token.new(:token_root, "$", 0, "$.foo .bar"),
+      Token.new(:token_name, "foo", 2, "$.foo .bar"),
+      Token.new(:token_name, "bar", 7, "$.foo .bar"),
+      Token.new(:token_eoi, "", 10, "$.foo .bar")
     ]
   },
   {
     name: "basic dot wild",
     query: "$.foo.*",
     want: [
-      Token.new(Token::ROOT, "$", 0, "$.foo.*"),
-      Token.new(Token::NAME, "foo", 2, "$.foo.*"),
-      Token.new(Token::WILD, "*", 6, "$.foo.*"),
-      Token.new(Token::EOI, "", 7, "$.foo.*")
+      Token.new(:token_root, "$", 0, "$.foo.*"),
+      Token.new(:token_name, "foo", 2, "$.foo.*"),
+      Token.new(:token_wild, "*", 6, "$.foo.*"),
+      Token.new(:token_eoi, "", 7, "$.foo.*")
     ]
   },
   {
     name: "basic recurse",
     query: "$..foo",
     want: [
-      Token.new(Token::ROOT, "$", 0, "$..foo"),
-      Token.new(Token::DOUBLE_DOT, "..", 1, "$..foo"),
-      Token.new(Token::NAME, "foo", 3, "$..foo"),
-      Token.new(Token::EOI, "", 6, "$..foo")
+      Token.new(:token_root, "$", 0, "$..foo"),
+      Token.new(:token_double_dot, "..", 1, "$..foo"),
+      Token.new(:token_name, "foo", 3, "$..foo"),
+      Token.new(:token_eoi, "", 6, "$..foo")
     ]
   },
   {
     name: "basic recurse with trailing dot",
     query: "$...foo",
     want: [
-      Token.new(Token::ROOT, "$", 0, "$...foo"),
-      Token.new(Token::DOUBLE_DOT, "..", 1, "$...foo"),
+      Token.new(:token_root, "$", 0, "$...foo"),
+      Token.new(:token_double_dot, "..", 1, "$...foo"),
       Token.new(
-        Token::ERROR,
+        :token_error,
         ".",
         3,
         "$...foo",
@@ -129,10 +129,10 @@ TEST_CASES = [
     name: "erroneous double recurse",
     query: "$....foo",
     want: [
-      Token.new(Token::ROOT, "$", 0, "$....foo"),
-      Token.new(Token::DOUBLE_DOT, "..", 1, "$....foo"),
+      Token.new(:token_root, "$", 0, "$....foo"),
+      Token.new(:token_double_dot, "..", 1, "$....foo"),
       Token.new(
-        Token::ERROR,
+        :token_error,
         ".",
         3,
         "$....foo",
@@ -144,323 +144,323 @@ TEST_CASES = [
     name: "bracketed name selector, double quotes",
     query: '$.foo["bar"]',
     want: [
-      Token.new(Token::ROOT, "$", 0, '$.foo["bar"]'),
-      Token.new(Token::NAME, "foo", 2, '$.foo["bar"]'),
-      Token.new(Token::LBRACKET, "[", 5, '$.foo["bar"]'),
-      Token.new(Token::DOUBLE_QUOTE_STRING, "bar", 7, '$.foo["bar"]'),
-      Token.new(Token::RBRACKET, "]", 11, '$.foo["bar"]'),
-      Token.new(Token::EOI, "", 12, '$.foo["bar"]')
+      Token.new(:token_root, "$", 0, '$.foo["bar"]'),
+      Token.new(:token_name, "foo", 2, '$.foo["bar"]'),
+      Token.new(:token_lbracket, "[", 5, '$.foo["bar"]'),
+      Token.new(:token_double_quote_string, "bar", 7, '$.foo["bar"]'),
+      Token.new(:token_rbracket, "]", 11, '$.foo["bar"]'),
+      Token.new(:token_eoi, "", 12, '$.foo["bar"]')
     ]
   },
   {
     name: "bracketed name selector, single quotes",
     query: "$.foo['bar']",
     want: [
-      Token.new(Token::ROOT, "$", 0, "$.foo['bar']"),
-      Token.new(Token::NAME, "foo", 2, "$.foo['bar']"),
-      Token.new(Token::LBRACKET, "[", 5, "$.foo['bar']"),
-      Token.new(Token::SINGLE_QUOTE_STRING, "bar", 7, "$.foo['bar']"),
-      Token.new(Token::RBRACKET, "]", 11, "$.foo['bar']"),
-      Token.new(Token::EOI, "", 12, "$.foo['bar']")
+      Token.new(:token_root, "$", 0, "$.foo['bar']"),
+      Token.new(:token_name, "foo", 2, "$.foo['bar']"),
+      Token.new(:token_lbracket, "[", 5, "$.foo['bar']"),
+      Token.new(:token_single_quote_string, "bar", 7, "$.foo['bar']"),
+      Token.new(:token_rbracket, "]", 11, "$.foo['bar']"),
+      Token.new(:token_eoi, "", 12, "$.foo['bar']")
     ]
   },
   {
     name: "multiple selectors",
     query: "$.foo['bar', 123, *]",
     want: [
-      Token.new(Token::ROOT, "$", 0, "$.foo['bar', 123, *]"),
-      Token.new(Token::NAME, "foo", 2, "$.foo['bar', 123, *]"),
-      Token.new(Token::LBRACKET, "[", 5, "$.foo['bar', 123, *]"),
-      Token.new(Token::SINGLE_QUOTE_STRING, "bar", 7, "$.foo['bar', 123, *]"),
-      Token.new(Token::COMMA, ",", 11, "$.foo['bar', 123, *]"),
-      Token.new(Token::INDEX, "123", 13, "$.foo['bar', 123, *]"),
-      Token.new(Token::COMMA, ",", 16, "$.foo['bar', 123, *]"),
-      Token.new(Token::WILD, "*", 18, "$.foo['bar', 123, *]"),
-      Token.new(Token::RBRACKET, "]", 19, "$.foo['bar', 123, *]"),
-      Token.new(Token::EOI, "", 20, "$.foo['bar', 123, *]")
+      Token.new(:token_root, "$", 0, "$.foo['bar', 123, *]"),
+      Token.new(:token_name, "foo", 2, "$.foo['bar', 123, *]"),
+      Token.new(:token_lbracket, "[", 5, "$.foo['bar', 123, *]"),
+      Token.new(:token_single_quote_string, "bar", 7, "$.foo['bar', 123, *]"),
+      Token.new(:token_comma, ",", 11, "$.foo['bar', 123, *]"),
+      Token.new(:token_index, "123", 13, "$.foo['bar', 123, *]"),
+      Token.new(:token_comma, ",", 16, "$.foo['bar', 123, *]"),
+      Token.new(:token_wild, "*", 18, "$.foo['bar', 123, *]"),
+      Token.new(:token_rbracket, "]", 19, "$.foo['bar', 123, *]"),
+      Token.new(:token_eoi, "", 20, "$.foo['bar', 123, *]")
     ]
   },
   {
     name: "slice",
     query: "$.foo[1:3]",
     want: [
-      Token.new(Token::ROOT, "$", 0, "$.foo[1:3]"),
-      Token.new(Token::NAME, "foo", 2, "$.foo[1:3]"),
-      Token.new(Token::LBRACKET, "[", 5, "$.foo[1:3]"),
-      Token.new(Token::INDEX, "1", 6, "$.foo[1:3]"),
-      Token.new(Token::COLON, ":", 7, "$.foo[1:3]"),
-      Token.new(Token::INDEX, "3", 8, "$.foo[1:3]"),
-      Token.new(Token::RBRACKET, "]", 9, "$.foo[1:3]"),
-      Token.new(Token::EOI, "", 10, "$.foo[1:3]")
+      Token.new(:token_root, "$", 0, "$.foo[1:3]"),
+      Token.new(:token_name, "foo", 2, "$.foo[1:3]"),
+      Token.new(:token_lbracket, "[", 5, "$.foo[1:3]"),
+      Token.new(:token_index, "1", 6, "$.foo[1:3]"),
+      Token.new(:token_colon, ":", 7, "$.foo[1:3]"),
+      Token.new(:token_index, "3", 8, "$.foo[1:3]"),
+      Token.new(:token_rbracket, "]", 9, "$.foo[1:3]"),
+      Token.new(:token_eoi, "", 10, "$.foo[1:3]")
     ]
   },
   {
     name: "filter",
     query: "$.foo[?@.bar]",
     want: [
-      Token.new(Token::ROOT, "$", 0, "$.foo[?@.bar]"),
-      Token.new(Token::NAME, "foo", 2, "$.foo[?@.bar]"),
-      Token.new(Token::LBRACKET, "[", 5, "$.foo[?@.bar]"),
-      Token.new(Token::FILTER, "?", 6, "$.foo[?@.bar]"),
-      Token.new(Token::CURRENT, "@", 7, "$.foo[?@.bar]"),
-      Token.new(Token::NAME, "bar", 9, "$.foo[?@.bar]"),
-      Token.new(Token::RBRACKET, "]", 12, "$.foo[?@.bar]"),
-      Token.new(Token::EOI, "", 13, "$.foo[?@.bar]")
+      Token.new(:token_root, "$", 0, "$.foo[?@.bar]"),
+      Token.new(:token_name, "foo", 2, "$.foo[?@.bar]"),
+      Token.new(:token_lbracket, "[", 5, "$.foo[?@.bar]"),
+      Token.new(:token_filter, "?", 6, "$.foo[?@.bar]"),
+      Token.new(:token_current, "@", 7, "$.foo[?@.bar]"),
+      Token.new(:token_name, "bar", 9, "$.foo[?@.bar]"),
+      Token.new(:token_rbracket, "]", 12, "$.foo[?@.bar]"),
+      Token.new(:token_eoi, "", 13, "$.foo[?@.bar]")
     ]
   },
   {
     name: "filter, parenthesized expression",
     query: "$.foo[?(@.bar)]",
     want: [
-      Token.new(Token::ROOT, "$", 0, "$.foo[?(@.bar)]"),
-      Token.new(Token::NAME, "foo", 2, "$.foo[?(@.bar)]"),
-      Token.new(Token::LBRACKET, "[", 5, "$.foo[?(@.bar)]"),
-      Token.new(Token::FILTER, "?", 6, "$.foo[?(@.bar)]"),
-      Token.new(Token::LPAREN, "(", 7, "$.foo[?(@.bar)]"),
-      Token.new(Token::CURRENT, "@", 8, "$.foo[?(@.bar)]"),
-      Token.new(Token::NAME, "bar", 10, "$.foo[?(@.bar)]"),
-      Token.new(Token::RPAREN, ")", 13, "$.foo[?(@.bar)]"),
-      Token.new(Token::RBRACKET, "]", 14, "$.foo[?(@.bar)]"),
-      Token.new(Token::EOI, "", 15, "$.foo[?(@.bar)]")
+      Token.new(:token_root, "$", 0, "$.foo[?(@.bar)]"),
+      Token.new(:token_name, "foo", 2, "$.foo[?(@.bar)]"),
+      Token.new(:token_lbracket, "[", 5, "$.foo[?(@.bar)]"),
+      Token.new(:token_filter, "?", 6, "$.foo[?(@.bar)]"),
+      Token.new(:token_lparen, "(", 7, "$.foo[?(@.bar)]"),
+      Token.new(:token_current, "@", 8, "$.foo[?(@.bar)]"),
+      Token.new(:token_name, "bar", 10, "$.foo[?(@.bar)]"),
+      Token.new(:token_rparen, ")", 13, "$.foo[?(@.bar)]"),
+      Token.new(:token_rbracket, "]", 14, "$.foo[?(@.bar)]"),
+      Token.new(:token_eoi, "", 15, "$.foo[?(@.bar)]")
     ]
   },
   {
     name: "two filters",
     query: "$.foo[?@.bar, ?@.baz]",
     want: [
-      Token.new(Token::ROOT, "$", 0, "$.foo[?@.bar, ?@.baz]"),
-      Token.new(Token::NAME, "foo", 2, "$.foo[?@.bar, ?@.baz]"),
-      Token.new(Token::LBRACKET, "[", 5, "$.foo[?@.bar, ?@.baz]"),
-      Token.new(Token::FILTER, "?", 6, "$.foo[?@.bar, ?@.baz]"),
-      Token.new(Token::CURRENT, "@", 7, "$.foo[?@.bar, ?@.baz]"),
-      Token.new(Token::NAME, "bar", 9, "$.foo[?@.bar, ?@.baz]"),
-      Token.new(Token::COMMA, ",", 12, "$.foo[?@.bar, ?@.baz]"),
-      Token.new(Token::FILTER, "?", 14, "$.foo[?@.bar, ?@.baz]"),
-      Token.new(Token::CURRENT, "@", 15, "$.foo[?@.bar, ?@.baz]"),
-      Token.new(Token::NAME, "baz", 17, "$.foo[?@.bar, ?@.baz]"),
-      Token.new(Token::RBRACKET, "]", 20, "$.foo[?@.bar, ?@.baz]"),
-      Token.new(Token::EOI, "", 21, "$.foo[?@.bar, ?@.baz]")
+      Token.new(:token_root, "$", 0, "$.foo[?@.bar, ?@.baz]"),
+      Token.new(:token_name, "foo", 2, "$.foo[?@.bar, ?@.baz]"),
+      Token.new(:token_lbracket, "[", 5, "$.foo[?@.bar, ?@.baz]"),
+      Token.new(:token_filter, "?", 6, "$.foo[?@.bar, ?@.baz]"),
+      Token.new(:token_current, "@", 7, "$.foo[?@.bar, ?@.baz]"),
+      Token.new(:token_name, "bar", 9, "$.foo[?@.bar, ?@.baz]"),
+      Token.new(:token_comma, ",", 12, "$.foo[?@.bar, ?@.baz]"),
+      Token.new(:token_filter, "?", 14, "$.foo[?@.bar, ?@.baz]"),
+      Token.new(:token_current, "@", 15, "$.foo[?@.bar, ?@.baz]"),
+      Token.new(:token_name, "baz", 17, "$.foo[?@.bar, ?@.baz]"),
+      Token.new(:token_rbracket, "]", 20, "$.foo[?@.bar, ?@.baz]"),
+      Token.new(:token_eoi, "", 21, "$.foo[?@.bar, ?@.baz]")
     ]
   },
   {
     name: "filter, function",
     query: "$[?count(@.foo)>2]",
     want: [
-      Token.new(Token::ROOT, "$", 0, "$[?count(@.foo)>2]"),
-      Token.new(Token::LBRACKET, "[", 1, "$[?count(@.foo)>2]"),
-      Token.new(Token::FILTER, "?", 2, "$[?count(@.foo)>2]"),
-      Token.new(Token::FUNCTION, "count", 3, "$[?count(@.foo)>2]"),
-      Token.new(Token::CURRENT, "@", 9, "$[?count(@.foo)>2]"),
-      Token.new(Token::NAME, "foo", 11, "$[?count(@.foo)>2]"),
-      Token.new(Token::RPAREN, ")", 14, "$[?count(@.foo)>2]"),
-      Token.new(Token::GT, ">", 15, "$[?count(@.foo)>2]"),
-      Token.new(Token::INT, "2", 16, "$[?count(@.foo)>2]"),
-      Token.new(Token::RBRACKET, "]", 17, "$[?count(@.foo)>2]"),
-      Token.new(Token::EOI, "", 18, "$[?count(@.foo)>2]")
+      Token.new(:token_root, "$", 0, "$[?count(@.foo)>2]"),
+      Token.new(:token_lbracket, "[", 1, "$[?count(@.foo)>2]"),
+      Token.new(:token_filter, "?", 2, "$[?count(@.foo)>2]"),
+      Token.new(:token_function, "count", 3, "$[?count(@.foo)>2]"),
+      Token.new(:token_current, "@", 9, "$[?count(@.foo)>2]"),
+      Token.new(:token_name, "foo", 11, "$[?count(@.foo)>2]"),
+      Token.new(:token_rparen, ")", 14, "$[?count(@.foo)>2]"),
+      Token.new(:token_gt, ">", 15, "$[?count(@.foo)>2]"),
+      Token.new(:token_int, "2", 16, "$[?count(@.foo)>2]"),
+      Token.new(:token_rbracket, "]", 17, "$[?count(@.foo)>2]"),
+      Token.new(:token_eoi, "", 18, "$[?count(@.foo)>2]")
     ]
   },
   {
     name: "filter, function with two args",
     query: "$[?count(@.foo, 1)>2]",
     want: [
-      Token.new(Token::ROOT, "$", 0, "$[?count(@.foo, 1)>2]"),
-      Token.new(Token::LBRACKET, "[", 1, "$[?count(@.foo, 1)>2]"),
-      Token.new(Token::FILTER, "?", 2, "$[?count(@.foo, 1)>2]"),
-      Token.new(Token::FUNCTION, "count", 3, "$[?count(@.foo, 1)>2]"),
-      Token.new(Token::CURRENT, "@", 9, "$[?count(@.foo, 1)>2]"),
-      Token.new(Token::NAME, "foo", 11, "$[?count(@.foo, 1)>2]"),
-      Token.new(Token::COMMA, ",", 14, "$[?count(@.foo, 1)>2]"),
-      Token.new(Token::INT, "1", 16, "$[?count(@.foo, 1)>2]"),
-      Token.new(Token::RPAREN, ")", 17, "$[?count(@.foo, 1)>2]"),
-      Token.new(Token::GT, ">", 18, "$[?count(@.foo, 1)>2]"),
-      Token.new(Token::INT, "2", 19, "$[?count(@.foo, 1)>2]"),
-      Token.new(Token::RBRACKET, "]", 20, "$[?count(@.foo, 1)>2]"),
-      Token.new(Token::EOI, "", 21, "$[?count(@.foo, 1)>2]")
+      Token.new(:token_root, "$", 0, "$[?count(@.foo, 1)>2]"),
+      Token.new(:token_lbracket, "[", 1, "$[?count(@.foo, 1)>2]"),
+      Token.new(:token_filter, "?", 2, "$[?count(@.foo, 1)>2]"),
+      Token.new(:token_function, "count", 3, "$[?count(@.foo, 1)>2]"),
+      Token.new(:token_current, "@", 9, "$[?count(@.foo, 1)>2]"),
+      Token.new(:token_name, "foo", 11, "$[?count(@.foo, 1)>2]"),
+      Token.new(:token_comma, ",", 14, "$[?count(@.foo, 1)>2]"),
+      Token.new(:token_int, "1", 16, "$[?count(@.foo, 1)>2]"),
+      Token.new(:token_rparen, ")", 17, "$[?count(@.foo, 1)>2]"),
+      Token.new(:token_gt, ">", 18, "$[?count(@.foo, 1)>2]"),
+      Token.new(:token_int, "2", 19, "$[?count(@.foo, 1)>2]"),
+      Token.new(:token_rbracket, "]", 20, "$[?count(@.foo, 1)>2]"),
+      Token.new(:token_eoi, "", 21, "$[?count(@.foo, 1)>2]")
     ]
   },
   {
     name: "filter, parenthesized function",
     query: "$[?(count(@.foo)>2)]",
     want: [
-      Token.new(Token::ROOT, "$", 0, "$[?(count(@.foo)>2)]"),
-      Token.new(Token::LBRACKET, "[", 1, "$[?(count(@.foo)>2)]"),
-      Token.new(Token::FILTER, "?", 2, "$[?(count(@.foo)>2)]"),
-      Token.new(Token::LPAREN, "(", 3, "$[?(count(@.foo)>2)]"),
-      Token.new(Token::FUNCTION, "count", 4, "$[?(count(@.foo)>2)]"),
-      Token.new(Token::CURRENT, "@", 10, "$[?(count(@.foo)>2)]"),
-      Token.new(Token::NAME, "foo", 12, "$[?(count(@.foo)>2)]"),
-      Token.new(Token::RPAREN, ")", 15, "$[?(count(@.foo)>2)]"),
-      Token.new(Token::GT, ">", 16, "$[?(count(@.foo)>2)]"),
-      Token.new(Token::INT, "2", 17, "$[?(count(@.foo)>2)]"),
-      Token.new(Token::RPAREN, ")", 18, "$[?(count(@.foo)>2)]"),
-      Token.new(Token::RBRACKET, "]", 19, "$[?(count(@.foo)>2)]"),
-      Token.new(Token::EOI, "", 20, "$[?(count(@.foo)>2)]")
+      Token.new(:token_root, "$", 0, "$[?(count(@.foo)>2)]"),
+      Token.new(:token_lbracket, "[", 1, "$[?(count(@.foo)>2)]"),
+      Token.new(:token_filter, "?", 2, "$[?(count(@.foo)>2)]"),
+      Token.new(:token_lparen, "(", 3, "$[?(count(@.foo)>2)]"),
+      Token.new(:token_function, "count", 4, "$[?(count(@.foo)>2)]"),
+      Token.new(:token_current, "@", 10, "$[?(count(@.foo)>2)]"),
+      Token.new(:token_name, "foo", 12, "$[?(count(@.foo)>2)]"),
+      Token.new(:token_rparen, ")", 15, "$[?(count(@.foo)>2)]"),
+      Token.new(:token_gt, ">", 16, "$[?(count(@.foo)>2)]"),
+      Token.new(:token_int, "2", 17, "$[?(count(@.foo)>2)]"),
+      Token.new(:token_rparen, ")", 18, "$[?(count(@.foo)>2)]"),
+      Token.new(:token_rbracket, "]", 19, "$[?(count(@.foo)>2)]"),
+      Token.new(:token_eoi, "", 20, "$[?(count(@.foo)>2)]")
     ]
   },
   {
     name: "filter, parenthesized function argument",
     query: "$[?(count((@.foo),1)>2)]",
     want: [
-      Token.new(Token::ROOT, "$", 0, "$[?(count((@.foo),1)>2)]"),
-      Token.new(Token::LBRACKET, "[", 1, "$[?(count((@.foo),1)>2)]"),
-      Token.new(Token::FILTER, "?", 2, "$[?(count((@.foo),1)>2)]"),
-      Token.new(Token::LPAREN, "(", 3, "$[?(count((@.foo),1)>2)]"),
-      Token.new(Token::FUNCTION, "count", 4, "$[?(count((@.foo),1)>2)]"),
-      Token.new(Token::LPAREN, "(", 10, "$[?(count((@.foo),1)>2)]"),
-      Token.new(Token::CURRENT, "@", 11, "$[?(count((@.foo),1)>2)]"),
-      Token.new(Token::NAME, "foo", 13, "$[?(count((@.foo),1)>2)]"),
-      Token.new(Token::RPAREN, ")", 16, "$[?(count((@.foo),1)>2)]"),
-      Token.new(Token::COMMA, ",", 17, "$[?(count((@.foo),1)>2)]"),
-      Token.new(Token::INT, "1", 18, "$[?(count((@.foo),1)>2)]"),
-      Token.new(Token::RPAREN, ")", 19, "$[?(count((@.foo),1)>2)]"),
-      Token.new(Token::GT, ">", 20, "$[?(count((@.foo),1)>2)]"),
-      Token.new(Token::INT, "2", 21, "$[?(count((@.foo),1)>2)]"),
-      Token.new(Token::RPAREN, ")", 22, "$[?(count((@.foo),1)>2)]"),
-      Token.new(Token::RBRACKET, "]", 23, "$[?(count((@.foo),1)>2)]"),
-      Token.new(Token::EOI, "", 24, "$[?(count((@.foo),1)>2)]")
+      Token.new(:token_root, "$", 0, "$[?(count((@.foo),1)>2)]"),
+      Token.new(:token_lbracket, "[", 1, "$[?(count((@.foo),1)>2)]"),
+      Token.new(:token_filter, "?", 2, "$[?(count((@.foo),1)>2)]"),
+      Token.new(:token_lparen, "(", 3, "$[?(count((@.foo),1)>2)]"),
+      Token.new(:token_function, "count", 4, "$[?(count((@.foo),1)>2)]"),
+      Token.new(:token_lparen, "(", 10, "$[?(count((@.foo),1)>2)]"),
+      Token.new(:token_current, "@", 11, "$[?(count((@.foo),1)>2)]"),
+      Token.new(:token_name, "foo", 13, "$[?(count((@.foo),1)>2)]"),
+      Token.new(:token_rparen, ")", 16, "$[?(count((@.foo),1)>2)]"),
+      Token.new(:token_comma, ",", 17, "$[?(count((@.foo),1)>2)]"),
+      Token.new(:token_int, "1", 18, "$[?(count((@.foo),1)>2)]"),
+      Token.new(:token_rparen, ")", 19, "$[?(count((@.foo),1)>2)]"),
+      Token.new(:token_gt, ">", 20, "$[?(count((@.foo),1)>2)]"),
+      Token.new(:token_int, "2", 21, "$[?(count((@.foo),1)>2)]"),
+      Token.new(:token_rparen, ")", 22, "$[?(count((@.foo),1)>2)]"),
+      Token.new(:token_rbracket, "]", 23, "$[?(count((@.foo),1)>2)]"),
+      Token.new(:token_eoi, "", 24, "$[?(count((@.foo),1)>2)]")
     ]
   },
   {
     name: "filter, nested",
     query: "$[?@[?@>1]]",
     want: [
-      Token.new(Token::ROOT, "$", 0, "$[?@[?@>1]]"),
-      Token.new(Token::LBRACKET, "[", 1, "$[?@[?@>1]]"),
-      Token.new(Token::FILTER, "?", 2, "$[?@[?@>1]]"),
-      Token.new(Token::CURRENT, "@", 3, "$[?@[?@>1]]"),
-      Token.new(Token::LBRACKET, "[", 4, "$[?@[?@>1]]"),
-      Token.new(Token::FILTER, "?", 5, "$[?@[?@>1]]"),
-      Token.new(Token::CURRENT, "@", 6, "$[?@[?@>1]]"),
-      Token.new(Token::GT, ">", 7, "$[?@[?@>1]]"),
-      Token.new(Token::INT, "1", 8, "$[?@[?@>1]]"),
-      Token.new(Token::RBRACKET, "]", 9, "$[?@[?@>1]]"),
-      Token.new(Token::RBRACKET, "]", 10, "$[?@[?@>1]]"),
-      Token.new(Token::EOI, "", 11, "$[?@[?@>1]]")
+      Token.new(:token_root, "$", 0, "$[?@[?@>1]]"),
+      Token.new(:token_lbracket, "[", 1, "$[?@[?@>1]]"),
+      Token.new(:token_filter, "?", 2, "$[?@[?@>1]]"),
+      Token.new(:token_current, "@", 3, "$[?@[?@>1]]"),
+      Token.new(:token_lbracket, "[", 4, "$[?@[?@>1]]"),
+      Token.new(:token_filter, "?", 5, "$[?@[?@>1]]"),
+      Token.new(:token_current, "@", 6, "$[?@[?@>1]]"),
+      Token.new(:token_gt, ">", 7, "$[?@[?@>1]]"),
+      Token.new(:token_int, "1", 8, "$[?@[?@>1]]"),
+      Token.new(:token_rbracket, "]", 9, "$[?@[?@>1]]"),
+      Token.new(:token_rbracket, "]", 10, "$[?@[?@>1]]"),
+      Token.new(:token_eoi, "", 11, "$[?@[?@>1]]")
     ]
   },
   {
     name: "filter, nested brackets",
     query: "$[?@[?@[1]>1]]",
     want: [
-      Token.new(Token::ROOT, "$", 0, "$[?@[?@[1]>1]]"),
-      Token.new(Token::LBRACKET, "[", 1, "$[?@[?@[1]>1]]"),
-      Token.new(Token::FILTER, "?", 2, "$[?@[?@[1]>1]]"),
-      Token.new(Token::CURRENT, "@", 3, "$[?@[?@[1]>1]]"),
-      Token.new(Token::LBRACKET, "[", 4, "$[?@[?@[1]>1]]"),
-      Token.new(Token::FILTER, "?", 5, "$[?@[?@[1]>1]]"),
-      Token.new(Token::CURRENT, "@", 6, "$[?@[?@[1]>1]]"),
-      Token.new(Token::LBRACKET, "[", 7, "$[?@[?@[1]>1]]"),
-      Token.new(Token::INDEX, "1", 8, "$[?@[?@[1]>1]]"),
-      Token.new(Token::RBRACKET, "]", 9, "$[?@[?@[1]>1]]"),
-      Token.new(Token::GT, ">", 10, "$[?@[?@[1]>1]]"),
-      Token.new(Token::INT, "1", 11, "$[?@[?@[1]>1]]"),
-      Token.new(Token::RBRACKET, "]", 12, "$[?@[?@[1]>1]]"),
-      Token.new(Token::RBRACKET, "]", 13, "$[?@[?@[1]>1]]"),
-      Token.new(Token::EOI, "", 14, "$[?@[?@[1]>1]]")
+      Token.new(:token_root, "$", 0, "$[?@[?@[1]>1]]"),
+      Token.new(:token_lbracket, "[", 1, "$[?@[?@[1]>1]]"),
+      Token.new(:token_filter, "?", 2, "$[?@[?@[1]>1]]"),
+      Token.new(:token_current, "@", 3, "$[?@[?@[1]>1]]"),
+      Token.new(:token_lbracket, "[", 4, "$[?@[?@[1]>1]]"),
+      Token.new(:token_filter, "?", 5, "$[?@[?@[1]>1]]"),
+      Token.new(:token_current, "@", 6, "$[?@[?@[1]>1]]"),
+      Token.new(:token_lbracket, "[", 7, "$[?@[?@[1]>1]]"),
+      Token.new(:token_index, "1", 8, "$[?@[?@[1]>1]]"),
+      Token.new(:token_rbracket, "]", 9, "$[?@[?@[1]>1]]"),
+      Token.new(:token_gt, ">", 10, "$[?@[?@[1]>1]]"),
+      Token.new(:token_int, "1", 11, "$[?@[?@[1]>1]]"),
+      Token.new(:token_rbracket, "]", 12, "$[?@[?@[1]>1]]"),
+      Token.new(:token_rbracket, "]", 13, "$[?@[?@[1]>1]]"),
+      Token.new(:token_eoi, "", 14, "$[?@[?@[1]>1]]")
     ]
   },
   {
     name: "function",
     query: "$[?foo()]",
     want: [
-      Token.new(Token::ROOT, "$", 0, "$[?foo()]"),
-      Token.new(Token::LBRACKET, "[", 1, "$[?foo()]"),
-      Token.new(Token::FILTER, "?", 2, "$[?foo()]"),
-      Token.new(Token::FUNCTION, "foo", 3, "$[?foo()]"),
-      Token.new(Token::RPAREN, ")", 7, "$[?foo()]"),
-      Token.new(Token::RBRACKET, "]", 8, "$[?foo()]"),
-      Token.new(Token::EOI, "", 9, "$[?foo()]")
+      Token.new(:token_root, "$", 0, "$[?foo()]"),
+      Token.new(:token_lbracket, "[", 1, "$[?foo()]"),
+      Token.new(:token_filter, "?", 2, "$[?foo()]"),
+      Token.new(:token_function, "foo", 3, "$[?foo()]"),
+      Token.new(:token_rparen, ")", 7, "$[?foo()]"),
+      Token.new(:token_rbracket, "]", 8, "$[?foo()]"),
+      Token.new(:token_eoi, "", 9, "$[?foo()]")
     ]
   },
   {
     name: "function, int literal",
     query: "$[?foo(42)]",
     want: [
-      Token.new(Token::ROOT, "$", 0, "$[?foo(42)]"),
-      Token.new(Token::LBRACKET, "[", 1, "$[?foo(42)]"),
-      Token.new(Token::FILTER, "?", 2, "$[?foo(42)]"),
-      Token.new(Token::FUNCTION, "foo", 3, "$[?foo(42)]"),
-      Token.new(Token::INT, "42", 7, "$[?foo(42)]"),
-      Token.new(Token::RPAREN, ")", 9, "$[?foo(42)]"),
-      Token.new(Token::RBRACKET, "]", 10, "$[?foo(42)]"),
-      Token.new(Token::EOI, "", 11, "$[?foo(42)]")
+      Token.new(:token_root, "$", 0, "$[?foo(42)]"),
+      Token.new(:token_lbracket, "[", 1, "$[?foo(42)]"),
+      Token.new(:token_filter, "?", 2, "$[?foo(42)]"),
+      Token.new(:token_function, "foo", 3, "$[?foo(42)]"),
+      Token.new(:token_int, "42", 7, "$[?foo(42)]"),
+      Token.new(:token_rparen, ")", 9, "$[?foo(42)]"),
+      Token.new(:token_rbracket, "]", 10, "$[?foo(42)]"),
+      Token.new(:token_eoi, "", 11, "$[?foo(42)]")
     ]
   },
   {
     name: "function, two int args",
     query: "$[?foo(42, -7)]",
     want: [
-      Token.new(Token::ROOT, "$", 0, "$[?foo(42, -7)]"),
-      Token.new(Token::LBRACKET, "[", 1, "$[?foo(42, -7)]"),
-      Token.new(Token::FILTER, "?", 2, "$[?foo(42, -7)]"),
-      Token.new(Token::FUNCTION, "foo", 3, "$[?foo(42, -7)]"),
-      Token.new(Token::INT, "42", 7, "$[?foo(42, -7)]"),
-      Token.new(Token::COMMA, ",", 9, "$[?foo(42, -7)]"),
-      Token.new(Token::INT, "-7", 11, "$[?foo(42, -7)]"),
-      Token.new(Token::RPAREN, ")", 13, "$[?foo(42, -7)]"),
-      Token.new(Token::RBRACKET, "]", 14, "$[?foo(42, -7)]"),
-      Token.new(Token::EOI, "", 15, "$[?foo(42, -7)]")
+      Token.new(:token_root, "$", 0, "$[?foo(42, -7)]"),
+      Token.new(:token_lbracket, "[", 1, "$[?foo(42, -7)]"),
+      Token.new(:token_filter, "?", 2, "$[?foo(42, -7)]"),
+      Token.new(:token_function, "foo", 3, "$[?foo(42, -7)]"),
+      Token.new(:token_int, "42", 7, "$[?foo(42, -7)]"),
+      Token.new(:token_comma, ",", 9, "$[?foo(42, -7)]"),
+      Token.new(:token_int, "-7", 11, "$[?foo(42, -7)]"),
+      Token.new(:token_rparen, ")", 13, "$[?foo(42, -7)]"),
+      Token.new(:token_rbracket, "]", 14, "$[?foo(42, -7)]"),
+      Token.new(:token_eoi, "", 15, "$[?foo(42, -7)]")
     ]
   },
   {
     name: "boolean literals",
     query: "$[?true==false]",
     want: [
-      Token.new(Token::ROOT, "$", 0, "$[?true==false]"),
-      Token.new(Token::LBRACKET, "[", 1, "$[?true==false]"),
-      Token.new(Token::FILTER, "?", 2, "$[?true==false]"),
-      Token.new(Token::TRUE, "true", 3, "$[?true==false]"),
-      Token.new(Token::EQ, "==", 7, "$[?true==false]"),
-      Token.new(Token::FALSE, "false", 9, "$[?true==false]"),
-      Token.new(Token::RBRACKET, "]", 14, "$[?true==false]"),
-      Token.new(Token::EOI, "", 15, "$[?true==false]")
+      Token.new(:token_root, "$", 0, "$[?true==false]"),
+      Token.new(:token_lbracket, "[", 1, "$[?true==false]"),
+      Token.new(:token_filter, "?", 2, "$[?true==false]"),
+      Token.new(:token_true, "true", 3, "$[?true==false]"),
+      Token.new(:token_eq, "==", 7, "$[?true==false]"),
+      Token.new(:token_false, "false", 9, "$[?true==false]"),
+      Token.new(:token_rbracket, "]", 14, "$[?true==false]"),
+      Token.new(:token_eoi, "", 15, "$[?true==false]")
     ]
   },
   {
     name: "logical and",
     query: "$[?true && false]",
     want: [
-      Token.new(Token::ROOT, "$", 0, "$[?true && false]"),
-      Token.new(Token::LBRACKET, "[", 1, "$[?true && false]"),
-      Token.new(Token::FILTER, "?", 2, "$[?true && false]"),
-      Token.new(Token::TRUE, "true", 3, "$[?true && false]"),
-      Token.new(Token::AND, "&&", 8, "$[?true && false]"),
-      Token.new(Token::FALSE, "false", 11, "$[?true && false]"),
-      Token.new(Token::RBRACKET, "]", 16, "$[?true && false]"),
-      Token.new(Token::EOI, "", 17, "$[?true && false]")
+      Token.new(:token_root, "$", 0, "$[?true && false]"),
+      Token.new(:token_lbracket, "[", 1, "$[?true && false]"),
+      Token.new(:token_filter, "?", 2, "$[?true && false]"),
+      Token.new(:token_true, "true", 3, "$[?true && false]"),
+      Token.new(:token_and, "&&", 8, "$[?true && false]"),
+      Token.new(:token_false, "false", 11, "$[?true && false]"),
+      Token.new(:token_rbracket, "]", 16, "$[?true && false]"),
+      Token.new(:token_eoi, "", 17, "$[?true && false]")
     ]
   },
   {
     name: "float",
     query: "$[?@.foo > 42.7]",
     want: [
-      Token.new(Token::ROOT, "$", 0, "$[?@.foo > 42.7]"),
-      Token.new(Token::LBRACKET, "[", 1, "$[?@.foo > 42.7]"),
-      Token.new(Token::FILTER, "?", 2, "$[?@.foo > 42.7]"),
-      Token.new(Token::CURRENT, "@", 3, "$[?@.foo > 42.7]"),
-      Token.new(Token::NAME, "foo", 5, "$[?@.foo > 42.7]"),
-      Token.new(Token::GT, ">", 9, "$[?@.foo > 42.7]"),
-      Token.new(Token::FLOAT, "42.7", 11, "$[?@.foo > 42.7]"),
-      Token.new(Token::RBRACKET, "]", 15, "$[?@.foo > 42.7]"),
-      Token.new(Token::EOI, "", 16, "$[?@.foo > 42.7]")
+      Token.new(:token_root, "$", 0, "$[?@.foo > 42.7]"),
+      Token.new(:token_lbracket, "[", 1, "$[?@.foo > 42.7]"),
+      Token.new(:token_filter, "?", 2, "$[?@.foo > 42.7]"),
+      Token.new(:token_current, "@", 3, "$[?@.foo > 42.7]"),
+      Token.new(:token_name, "foo", 5, "$[?@.foo > 42.7]"),
+      Token.new(:token_gt, ">", 9, "$[?@.foo > 42.7]"),
+      Token.new(:token_float, "42.7", 11, "$[?@.foo > 42.7]"),
+      Token.new(:token_rbracket, "]", 15, "$[?@.foo > 42.7]"),
+      Token.new(:token_eoi, "", 16, "$[?@.foo > 42.7]")
     ]
   },
   {
     name: "trailing dot",
     query: "$.foo.",
     want: [
-      Token.new(Token::ROOT, "$", 0, "$.foo."),
-      Token.new(Token::NAME, "foo", 2, "$.foo."),
-      Token.new(Token::ERROR, ".", 5, "$.foo.", message: "unexpected trailing dot")
+      Token.new(:token_root, "$", 0, "$.foo."),
+      Token.new(:token_name, "foo", 2, "$.foo."),
+      Token.new(:token_error, ".", 5, "$.foo.", message: "unexpected trailing dot")
     ]
   },
   {
     name: "unknown shorthand selector",
     query: "$.foo.&",
     want: [
-      Token.new(Token::ROOT, "$", 0, "$.foo.&"),
-      Token.new(Token::NAME, "foo", 2, "$.foo.&"),
-      Token.new(Token::ERROR, "&", 6, "$.foo.&", message: "unexpected shorthand selector '&'")
+      Token.new(:token_root, "$", 0, "$.foo.&"),
+      Token.new(:token_name, "foo", 2, "$.foo.&"),
+      Token.new(:token_error, "&", 6, "$.foo.&", message: "unexpected shorthand selector '&'")
     ]
   }
 ].freeze


### PR DESCRIPTION
This PR removes `Token` constants in favour of using `:token_` symbols directly. We now rely on type checking with Steep to tell us if we're using an unknown symbol.

We also replace range-based string slicing with start and length-based slicing.