### PR TITLE
Add `find_enum`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.4.0] - (unreleased)
+
+- Added `JSONP3.find_enum`, `JSONP3::JSONPathEnvironment.find_enum` and `JSONP3::JSONPath.find_enum`. `find_enum` is like `find`, but returns an Enumerable (usually an Enumerator) of `JSONPathNode` instances instead of a `JSONPathNodeList`. `find_enum` can be more efficient for some combinations of query and data, especially for large data and recursive queries.
+
 ## [0.3.2] - 2025-01-29
 
 - Fix normalized string representations of node locations as returned by `JSONPathNode.path`.

--- a/README.md
+++ b/README.md
@@ -192,6 +192,23 @@ end
 # {"name"=>"John", "score"=>86, "admin"=>true} at $['users'][2]
 ```
 
+### find_enum
+
+`find_enum(query, value) -> Enumerable<JSONPathNode>`
+
+`find_enum` is an alternative to `find` which returns an enumerable (usually an enumerator) of `JSONPathNode` instances instead of an array. Depending on the query and the data the query is applied to, `find_enum` can be more efficient than `find`, especially for large data and queries using recursive descent segments.
+
+```ruby
+# ... continued from above
+
+JSONP3.find_enum("$.users[?@.score > 85]", data).each do |node|
+  puts "#{node.value} at #{node.path}"
+end
+
+# {"name"=>"Sue", "score"=>100} at $['users'][0]
+# {"name"=>"John", "score"=>86, "admin"=>true} at $['users'][2]
+```
+
 ### compile
 
 `compile(query) -> JSONPath`
@@ -240,10 +257,14 @@ end
 
 ### JSONPathEnvironment
 
-The `find` and `compile` methods described above are convenience methods equivalent to
+The `find`, `find_enum` and `compile` methods described above are convenience methods equivalent to
 
 ```
 JSONP3::DEFAULT_ENVIRONMENT.find(query, data)
+```
+
+```
+JSONP3::DEFAULT_ENVIRONMENT.find_enum(query, data)
 ```
 
 and

--- a/lib/json_p3.rb
+++ b/lib/json_p3.rb
@@ -13,6 +13,10 @@ module JSONP3
     DefaultEnvironment.find(path, data)
   end
 
+  def self.find_enum(path, data)
+    DefaultEnvironment.find_enum(path, data)
+  end
+
   def self.compile(path)
     DefaultEnvironment.compile(path)
   end

--- a/lib/json_p3/environment.rb
+++ b/lib/json_p3/environment.rb
@@ -63,6 +63,14 @@ module JSONP3
       compile(query).find(value)
     end
 
+    # Apply JSONPath expression _query_ to _value_.
+    # @param query [String] the JSONPath expression
+    # @param value [JSON-like data] the target JSON "document"
+    # @return [Enumerable<JSONPath>]
+    def find_enum(query, value)
+      compile(query).find_enum(value)
+    end
+
     # Override this function to configure JSONPath function extensions.
     # By default, only the standard functions described in RFC 9535 are enabled.
     def setup_function_extensions

--- a/lib/json_p3/path.rb
+++ b/lib/json_p3/path.rb
@@ -20,10 +20,19 @@ module JSONP3
     def find(root)
       nodes = [JSONPathNode.new(root, [], root)]
       @segments.each { |segment| nodes = segment.resolve(nodes) }
-      JSONPathNodeList.new(nodes.to_a)
+      JSONPathNodeList.new(nodes) # TODO: use JSONPathNodeList internally?
     end
 
     alias apply find
+
+    # Apply this JSONPath expression to JSON-like value _root_.
+    # @param root [Array, Hash, String, Integer, nil] the root JSON-like value to apply this query to.
+    # @return [Enumerable<JSONPathNode>] the sequence of nodes found while applying this query to _root_.
+    def find_enum(root)
+      nodes = [JSONPathNode.new(root, [], root)]
+      @segments.each { |segment| nodes = segment.resolve_enum(nodes) }
+      nodes
+    end
 
     # Return _true_ if this JSONPath expression is a singular query.
     def singular?

--- a/lib/json_p3/path.rb
+++ b/lib/json_p3/path.rb
@@ -20,7 +20,7 @@ module JSONP3
     def find(root)
       nodes = [JSONPathNode.new(root, [], root)]
       @segments.each { |segment| nodes = segment.resolve(nodes) }
-      JSONPathNodeList.new(nodes)
+      JSONPathNodeList.new(nodes.to_a)
     end
 
     alias apply find

--- a/lib/json_p3/selector.rb
+++ b/lib/json_p3/selector.rb
@@ -12,7 +12,7 @@ module JSONP3
     end
 
     # Apply this selector to _node_.
-    # @return [Array<JSONPathNode>]
+    # @return [Enumerable<JSONPathNode>]
     def resolve(_node)
       raise "selectors must implement resolve(node)"
     end

--- a/lib/json_p3/selector.rb
+++ b/lib/json_p3/selector.rb
@@ -12,9 +12,15 @@ module JSONP3
     end
 
     # Apply this selector to _node_.
-    # @return [Enumerable<JSONPathNode>]
+    # @return [Array<JSONPathNode>]
     def resolve(_node)
       raise "selectors must implement resolve(node)"
+    end
+
+    # Apply this selector to _node_.
+    # @return [Enumerable<JSONPathNode>]
+    def resolve_enum(node)
+      resolve(node)
     end
 
     # Return true if this selector is a singular selector.
@@ -145,6 +151,24 @@ module JSONP3
       end
     end
 
+    def resolve_enum(node)
+      if node.value.is_a? Hash
+        Enumerator.new do |yielder|
+          node.value.each do |k, v|
+            yielder << node.new_child(v, k)
+          end
+        end
+      elsif node.value.is_a? Array
+        Enumerator.new do |yielder|
+          node.value.each.with_index do |e, i|
+            yielder << node.new_child(e, i)
+          end
+        end
+      else
+        []
+      end
+    end
+
     def to_s
       "*"
     end
@@ -264,6 +288,22 @@ module JSONP3
       end
 
       nodes
+    end
+
+    def resolve_enum(node)
+      Enumerator.new do |yielder|
+        if node.value.is_a?(Array)
+          node.value.each_with_index do |e, i|
+            context = FilterContext.new(@env, e, node.root)
+            yielder << node.new_child(e, i) if @expression.evaluate(context)
+          end
+        elsif node.value.is_a?(Hash)
+          node.value.each_pair do |k, v|
+            context = FilterContext.new(@env, v, node.root)
+            yielder << node.new_child(v, k) if @expression.evaluate(context)
+          end
+        end
+      end
     end
 
     def to_s

--- a/sig/json_p3.rbs
+++ b/sig/json_p3.rbs
@@ -65,6 +65,8 @@ module JSONP3
     # @param value [JSON-like data]
     # @return [Array<JSONPath>]
     def find: (String query, untyped value) -> JSONPathNodeList
+            
+    def find_enum: (String query, untyped value) -> Enumerable[JSONPathNode]
 
     def setup_function_extensions: () -> void
   end
@@ -626,7 +628,9 @@ module JSONP3
     # Apply this JSONPath expression to JSON-like value _root_.
     # @param root [Array, Hash, String, Integer] the root JSON-like value to apply this query to.
     # @return [Array<JSONPathNode>] the sequence of nodes found while applying this query to _root_.
-    def find: (untyped root) -> untyped
+    def find: (untyped root) -> JSONPathNodeList
+            
+    def find_enum: (untyped root) -> Enumerable[JSONPathNode]
 
     alias apply find
 
@@ -656,12 +660,17 @@ module JSONP3
     def initialize: (JSONPathEnvironment env, Token token, Array[Selector] selectors) -> void
 
     # Select the children of each node in _nodes_.
-    def resolve: (Enumerable[JSONPathNode] _nodes) -> Enumerable[JSONPathNode]
+    def resolve: (Array[JSONPathNode] _nodes) -> Array[JSONPathNode]
+
+    # Select the children of each node in _nodes_.
+    def resolve_enum: (Enumerable[JSONPathNode] _nodes) -> Enumerable[JSONPathNode]
   end
 
   # The child selection segment.
   class ChildSegment < Segment
-    def resolve: (Enumerable[JSONPathNode] nodes) -> Enumerable[JSONPathNode]
+    def resolve: (Array[JSONPathNode] nodes) -> Array[JSONPathNode]
+               
+    def resolve_enum: (Enumerable[JSONPathNode] nodes) -> Enumerable[JSONPathNode]
 
     def to_s: () -> ::String
 
@@ -674,7 +683,9 @@ module JSONP3
 
   # The recursive descent segment
   class RecursiveDescentSegment < Segment
-    def resolve: (Enumerable[JSONPathNode] nodes) -> Enumerable[JSONPathNode]
+    def resolve: (Array[JSONPathNode] nodes) -> Array[JSONPathNode]
+               
+    def resolve_enum: (Enumerable[JSONPathNode] nodes) -> Enumerable[JSONPathNode]
 
     def to_s: () -> ::String
 
@@ -702,7 +713,8 @@ module JSONP3
 
     # Apply this selector to _node_.
     # @return [Array<JSONPathNode>]
-    def resolve: (JSONPathNode _node) -> Enumerable[JSONPathNode]
+    def resolve: (JSONPathNode _node) -> Array[JSONPathNode]
+    def resolve_enum: (JSONPathNode _node) -> Enumerable[JSONPathNode]
 
     # Return true if this selector is a singular selector.
     def singular?: () -> false
@@ -717,7 +729,8 @@ module JSONP3
 
     def initialize: (JSONPathEnvironment env, Token token, String name) -> void
 
-    def resolve: (JSONPathNode node) -> Enumerable[JSONPathNode]
+    def resolve: (JSONPathNode node) -> ::Array[JSONPathNode]
+    def resolve_enum: (JSONPathNode node) -> Enumerable[JSONPathNode]
 
     def singular?: () -> true
 
@@ -740,7 +753,8 @@ module JSONP3
 
     def initialize: (JSONPathEnvironment env, Token token, String name) -> void
 
-    def resolve: (JSONPathNode node) -> Enumerable[JSONPathNode]
+    def resolve: (JSONPathNode node) -> ::Array[JSONPathNode]
+    def resolve_enum: (JSONPathNode node) -> Enumerable[JSONPathNode]
 
     def singular?: () -> true
 
@@ -762,7 +776,8 @@ module JSONP3
 
     def initialize: (JSONPathEnvironment env, Token token, Integer index) -> void
 
-    def resolve: (JSONPathNode node) -> Enumerable[JSONPathNode]
+    def resolve: (JSONPathNode node) -> ::Array[JSONPathNode]
+    def resolve_enum: (JSONPathNode node) -> Enumerable[JSONPathNode]
 
     def singular?: () -> true
 
@@ -781,7 +796,8 @@ module JSONP3
 
   # The wildcard selector selects all elements from an array or values from a hash.
   class WildcardSelector < Selector
-    def resolve: (JSONPathNode node) -> Enumerable[JSONPathNode]
+    def resolve: (JSONPathNode node) -> ::Array[JSONPathNode]
+    def resolve_enum: (JSONPathNode node) -> Enumerable[JSONPathNode]
 
     def to_s: () -> "*"
 
@@ -811,7 +827,8 @@ module JSONP3
 
     def initialize: (JSONPathEnvironment env, Token token, (Integer | nil) start, (Integer | nil) stop, (Integer | nil) step) -> void
 
-    def resolve: (JSONPathNode node) -> Enumerable[JSONPathNode]
+    def resolve: (JSONPathNode node) -> ::Array[JSONPathNode]
+    def resolve_enum: (JSONPathNode node) -> Enumerable[JSONPathNode]
 
     def to_s: () -> ::String
 
@@ -837,7 +854,8 @@ module JSONP3
 
     def initialize: (JSONPathEnvironment env, Token token, Expression expression) -> void
 
-    def resolve: (JSONPathNode node) -> Enumerable[JSONPathNode]
+    def resolve: (JSONPathNode node) -> ::Array[JSONPathNode]
+    def resolve_enum: (JSONPathNode node) -> Enumerable[JSONPathNode]
 
     def to_s: () -> ::String
 

--- a/sig/json_p3.rbs
+++ b/sig/json_p3.rbs
@@ -656,12 +656,12 @@ module JSONP3
     def initialize: (JSONPathEnvironment env, Token token, Array[Selector] selectors) -> void
 
     # Select the children of each node in _nodes_.
-    def resolve: (Array[JSONPathNode] _nodes) -> Array[JSONPathNode]
+    def resolve: (Enumerable[JSONPathNode] _nodes) -> Enumerable[JSONPathNode]
   end
 
   # The child selection segment.
   class ChildSegment < Segment
-    def resolve: (Array[JSONPathNode] nodes) -> Array[JSONPathNode]
+    def resolve: (Enumerable[JSONPathNode] nodes) -> Enumerable[JSONPathNode]
 
     def to_s: () -> ::String
 
@@ -674,7 +674,7 @@ module JSONP3
 
   # The recursive descent segment
   class RecursiveDescentSegment < Segment
-    def resolve: (Array[JSONPathNode] nodes) -> Array[JSONPathNode]
+    def resolve: (Enumerable[JSONPathNode] nodes) -> Enumerable[JSONPathNode]
 
     def to_s: () -> ::String
 
@@ -684,7 +684,7 @@ module JSONP3
 
     def hash: () -> Integer
 
-    def visit: (JSONPathNode node, ?::Integer depth) -> Array[JSONPathNode]
+    def visit: (JSONPathNode node, ?::Integer depth) -> Enumerable[JSONPathNode]
   end
 end
 
@@ -702,7 +702,7 @@ module JSONP3
 
     # Apply this selector to _node_.
     # @return [Array<JSONPathNode>]
-    def resolve: (JSONPathNode _node) -> Array[JSONPathNode]
+    def resolve: (JSONPathNode _node) -> Enumerable[JSONPathNode]
 
     # Return true if this selector is a singular selector.
     def singular?: () -> false
@@ -717,7 +717,7 @@ module JSONP3
 
     def initialize: (JSONPathEnvironment env, Token token, String name) -> void
 
-    def resolve: (JSONPathNode node) -> ::Array[JSONPathNode]
+    def resolve: (JSONPathNode node) -> Enumerable[JSONPathNode]
 
     def singular?: () -> true
 
@@ -740,7 +740,7 @@ module JSONP3
 
     def initialize: (JSONPathEnvironment env, Token token, String name) -> void
 
-    def resolve: (JSONPathNode node) -> ::Array[JSONPathNode]
+    def resolve: (JSONPathNode node) -> Enumerable[JSONPathNode]
 
     def singular?: () -> true
 
@@ -762,7 +762,7 @@ module JSONP3
 
     def initialize: (JSONPathEnvironment env, Token token, Integer index) -> void
 
-    def resolve: (JSONPathNode node) -> Array[JSONPathNode]
+    def resolve: (JSONPathNode node) -> Enumerable[JSONPathNode]
 
     def singular?: () -> true
 
@@ -781,7 +781,7 @@ module JSONP3
 
   # The wildcard selector selects all elements from an array or values from a hash.
   class WildcardSelector < Selector
-    def resolve: (JSONPathNode node) -> Array[JSONPathNode]
+    def resolve: (JSONPathNode node) -> Enumerable[JSONPathNode]
 
     def to_s: () -> "*"
 
@@ -811,7 +811,7 @@ module JSONP3
 
     def initialize: (JSONPathEnvironment env, Token token, (Integer | nil) start, (Integer | nil) stop, (Integer | nil) step) -> void
 
-    def resolve: (JSONPathNode node) -> Array[JSONPathNode]
+    def resolve: (JSONPathNode node) -> Enumerable[JSONPathNode]
 
     def to_s: () -> ::String
 
@@ -837,7 +837,7 @@ module JSONP3
 
     def initialize: (JSONPathEnvironment env, Token token, Expression expression) -> void
 
-    def resolve: (JSONPathNode node) -> Array[JSONPathNode]
+    def resolve: (JSONPathNode node) -> Enumerable[JSONPathNode]
 
     def to_s: () -> ::String
 

--- a/test/test_compliance.rb
+++ b/test/test_compliance.rb
@@ -25,4 +25,24 @@ class TestCompliance < Minitest::Spec
       end
     end
   end
+
+  describe "compliance enum" do
+    cts["tests"].each do |test_case|
+      it test_case["name"] do
+        if test_case.key? "result"
+          enum = JSONP3.find_enum(test_case["selector"], test_case["document"])
+          nodes = enum.to_a
+          _(nodes.map(&:value)).must_equal(test_case["result"])
+        elsif test_case.key? "results"
+          enum = JSONP3.find_enum(test_case["selector"], test_case["document"])
+          nodes = enum.to_a
+          _(test_case["results"]).must_include(nodes.map(&:value))
+        elsif test_case.key? "invalid_selector"
+          assert_raises JSONP3::JSONPathError do
+            JSONP3.compile(test_case["selector"])
+          end
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
This PR adds `JSONP3.find_enum`, `JSONP3::JSONPathEnvironment.find_enum` and `JSONP3::JSONPath.find_enum`. `find_enum` is like `find`, but returns an Enumerable (usually an Enumerator) of `JSONPathNode` instances instead of a `JSONPathNodeList`. `find_enum` can be more efficient for some combinations of query and data, especially for large data and recursive queries.