### PR TITLE
Fix unbalanced parentheses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.4.1] - unreleased
+
+- Fixed `JSONPathSyntaxError` claiming "unbalanced parentheses" when the query has balanced brackets.
+
 ## [0.4.0] - 2025-02-10
 
 - Added `JSONP3.find_enum`, `JSONP3::JSONPathEnvironment.find_enum` and `JSONP3::JSONPath.find_enum`. `find_enum` is like `find`, but returns an Enumerable (usually an Enumerator) of `JSONPathNode` instances instead of a `JSONPathNodeList`. `find_enum` can be more efficient for some combinations of query and data, especially for large data and recursive queries.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    json_p3 (0.4.0)
+    json_p3 (0.4.1)
 
 GEM
   remote: https://rubygems.org/
@@ -27,7 +27,6 @@ GEM
     concurrent-ruby (1.3.5)
     connection_pool (2.5.0)
     csv (3.3.2)
-    date (3.4.1)
     drb (2.2.1)
     ffi (1.17.1)
     ffi (1.17.1-x86_64-linux-gnu)
@@ -50,9 +49,6 @@ GEM
     parser (3.3.7.1)
       ast (~> 2.4.1)
       racc
-    psych (5.2.3)
-      date
-      stringio
     racc (1.8.1)
     rainbow (3.1.1)
     rake (13.2.1)
@@ -61,8 +57,6 @@ GEM
       ffi (~> 1.0)
     rbs (3.8.1)
       logger
-    rdoc (6.12.0)
-      psych (>= 4.0.0)
     redcarpet (3.6.1)
     regexp_parser (2.10.0)
     rubocop (1.73.2)
@@ -106,7 +100,6 @@ GEM
       strscan (>= 1.0.0)
       terminal-table (>= 2, < 4)
       uri (>= 0.12.0)
-    stringio (3.1.5)
     strscan (3.1.2)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
@@ -127,7 +120,6 @@ DEPENDENCIES
   minitest (~> 5.16)
   minitest-fail-fast (~> 0.1.0)
   rake (~> 13.0)
-  rdoc (~> 6.7)
   redcarpet (~> 3.6)
   rubocop (~> 1.21)
   rubocop-minitest (~> 0.36.0)

--- a/lib/json_p3/lexer.rb
+++ b/lib/json_p3/lexer.rb
@@ -15,15 +15,15 @@ module JSONP3 # rubocop:disable Style/Documentation
     lexer.run
     tokens = lexer.tokens
 
+    if !tokens.empty? && tokens.last.type == :token_error
+      raise JSONPathSyntaxError.new(tokens.last.message || raise,
+                                    tokens.last)
+    end
+
     unless lexer.bracket_stack.empty?
       ch, index = *lexer.bracket_stack.last
       msg = "unbalanced brackets"
       raise JSONPathSyntaxError.new(msg, Token.new(:token_error, ch, index, query, message: msg))
-    end
-
-    if !tokens.empty? && tokens.last.type == :token_error
-      raise JSONPathSyntaxError.new(tokens.last.message || raise,
-                                    tokens.last)
     end
 
     tokens

--- a/lib/json_p3/lexer.rb
+++ b/lib/json_p3/lexer.rb
@@ -15,6 +15,12 @@ module JSONP3 # rubocop:disable Style/Documentation
     lexer.run
     tokens = lexer.tokens
 
+    unless lexer.bracket_stack.empty?
+      ch, index = *lexer.bracket_stack.last
+      msg = "unbalanced brackets"
+      raise JSONPathSyntaxError.new(msg, Token.new(:token_error, ch, index, query, message: msg))
+    end
+
     if !tokens.empty? && tokens.last.type == :token_error
       raise JSONPathSyntaxError.new(tokens.last.message || raise,
                                     tokens.last)
@@ -33,11 +39,12 @@ module JSONP3 # rubocop:disable Style/Documentation
     S_ESCAPES = Set["b", "f", "n", "r", "t", "u", "/", "\\"].freeze
 
     # @dynamic tokens
-    attr_reader :tokens
+    attr_reader :tokens, :bracket_stack
 
     def initialize(query)
       @filter_depth = 0
-      @paren_stack = []
+      @func_call_stack = []
+      @bracket_stack = []
       @tokens = []
       @start = 0
       @query = query.freeze
@@ -135,6 +142,7 @@ module JSONP3 # rubocop:disable Style/Documentation
         emit(:token_double_dot, "..")
         :lex_descendant_segment
       when "["
+        @bracket_stack << ["[", @start]
         emit(:token_lbracket, "[")
         :lex_inside_bracketed_segment
       else
@@ -157,6 +165,7 @@ module JSONP3 # rubocop:disable Style/Documentation
         emit(:token_wild, "*")
         :lex_segment
       when "["
+        @bracket_stack << ["[", @start]
         emit(:token_lbracket, "[")
         :lex_inside_bracketed_segment
       else
@@ -208,6 +217,13 @@ module JSONP3 # rubocop:disable Style/Documentation
 
         case c
         when "]"
+          if @bracket_stack.empty? || @bracket_stack.last.first != "["
+            backup
+            error "unbalanced brackets"
+            return nil
+          end
+
+          @bracket_stack.pop
           emit(:token_rbracket, "]")
           return :lex_segment
         when ""
@@ -251,17 +267,13 @@ module JSONP3 # rubocop:disable Style/Documentation
           return nil
         when "]"
           @filter_depth -= 1
-          if @paren_stack.length == 1
-            error "unbalanced parentheses"
-            return nil
-          end
           backup
           return :lex_inside_bracketed_segment
         when ","
           emit(:token_comma, ",")
           # If we have unbalanced parens, we are inside a function call and a
           # comma separates arguments. Otherwise a comma separates selectors.
-          next if @paren_stack.length.positive?
+          next if @func_call_stack.length.positive?
 
           @filter_depth -= 1
           return :lex_inside_bracketed_segment
@@ -270,17 +282,25 @@ module JSONP3 # rubocop:disable Style/Documentation
         when '"'
           return :lex_double_quoted_string_inside_filter_expression
         when "("
+          @bracket_stack << ["(", @start]
           emit(:token_lparen, "(")
           # Are we in a function call? If so, a function argument contains parens.
-          @paren_stack[-1] += 1 if @paren_stack.length.positive?
+          @func_call_stack[-1] += 1 if @func_call_stack.length.positive?
         when ")"
+          if @bracket_stack.empty? || @bracket_stack.last.first != "("
+            backup
+            error "unbalanced brackets"
+            return nil
+          end
+
+          @bracket_stack.pop
           emit(:token_rparen, ")")
           # Are we closing a function call or a parenthesized expression?
-          if @paren_stack.length.positive?
-            if @paren_stack[-1] == 1
-              @paren_stack.pop
+          if @func_call_stack.length.positive?
+            if @func_call_stack[-1] == 1
+              @func_call_stack.pop
             else
-              @paren_stack[-1] -= 1
+              @func_call_stack[-1] -= 1
             end
           end
         when "$"
@@ -359,8 +379,9 @@ module JSONP3 # rubocop:disable Style/Documentation
             end
             # Function name
             # Keep track of parentheses for this function call.
-            @paren_stack << 1
+            @func_call_stack << 1
             emit :token_function
+            @bracket_stack << ["(", @start]
             self.next
             ignore # move past LPAREN
           else

--- a/lib/json_p3/version.rb
+++ b/lib/json_p3/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module JSONP3
-  VERSION = "0.4.0"
+  VERSION = "0.4.1"
 end

--- a/sig/json_p3.rbs
+++ b/sig/json_p3.rbs
@@ -432,6 +432,8 @@ module JSONP3
 
     @paren_stack: Array[Integer]
 
+    @bracket_stack: Array[Array[untyped]]
+
     @tokens: Array[Token]
 
     @start: Integer
@@ -450,6 +452,9 @@ module JSONP3
 
     # @dynamic tokens
     attr_reader tokens: Array[Token]
+
+    # @dynamic tokens
+    attr_reader bracket_stack: Array[Array[untyped]]
 
     def initialize: (String query) -> void
 

--- a/test/test_errors.rb
+++ b/test/test_errors.rb
@@ -23,4 +23,16 @@ class TestErrors < Minitest::Test
 
     assert_raises(JSONP3::JSONPathRecursionError) { path.find(data) }
   end
+
+  def test_unclosed_selection_list
+    assert_raises(JSONP3::JSONPathSyntaxError) { JSONP3.compile("$[1,2") }
+  end
+
+  def test_unclosed_selection_list_inside_filter
+    assert_raises(JSONP3::JSONPathSyntaxError) { JSONP3.compile("$[?@.a < 1") }
+  end
+
+  def test_nested_functions_with_unbalanced_parens
+    assert_raises(JSONP3::JSONPathSyntaxError) { JSONP3.compile("$.values[?match(@.a, value($..['regex'])]") }
+  end
 end

--- a/test/test_issues.rb
+++ b/test/test_issues.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class TestErrors < Minitest::Test
+  def test_issue22
+    assert_instance_of(JSONP3::JSONPath, JSONP3.compile("$[? count(@.likes[? @.location]) > 3]"))
+  end
+end


### PR DESCRIPTION
See #22

**Too few closing brackets**

```ruby
require "json_p3"

JSONP3.find("$.values[?match(@.a, value($..['regex'])]", {}).each do |node|
  puts "#{node.value} at #{node.path}"
end

#   -> '$.values[?match(@.a, value($..['regex'])]' 1:40
#   |
# 1 | $.values[?match(@.a, value($..['regex'])]
#   |                                         ^ unbalanced brackets
```

**Too many closing brackets**

```ruby
require "json_p3"

JSONP3.find("$.values[?match(@.a, value($..['regex'])))]", {}).each do |node|
  puts "#{node.value} at #{node.path}"
end

#   -> '$.values[?match(@.a, value($..['regex'])))]' 1:41
#   |
# 1 | $.values[?match(@.a, value($..['regex'])))]
#   |                                          ^ unbalanced brackets
```